### PR TITLE
Nrp 0.4.0

### DIFF
--- a/CMake/GitExternal.cmake
+++ b/CMake/GitExternal.cmake
@@ -23,6 +23,9 @@
 #    when only a specific branch of a repo is required and the full history
 #    is not required. Note that the SHALLOW option will only work for a branch
 #    or tag and cannot be used for an arbitrary SHA.
+#  OPTIONAL, when present, this option makes this operation optional.
+#    The function will output a warning and return if the repo could not be
+#    cloned.
 #
 # Targets:
 #  * <directory>-rebase: fetches latest updates and rebases the given external
@@ -74,7 +77,7 @@ function(JOIN VALUES GLUE OUTPUT)
 endfunction()
 
 function(GIT_EXTERNAL DIR REPO tag)
-  cmake_parse_arguments(GIT_EXTERNAL_LOCAL "VERBOSE;SHALLOW" "" "RESET" ${ARGN})
+  cmake_parse_arguments(GIT_EXTERNAL_LOCAL "VERBOSE;SHALLOW;OPTIONAL" "" "RESET" ${ARGN})
   set(TAG ${tag})
   if(GIT_EXTERNAL_TAG AND "${tag}" MATCHES "^[0-9a-f]+$")
     set(TAG ${GIT_EXTERNAL_TAG})
@@ -115,7 +118,12 @@ function(GIT_EXTERNAL DIR REPO tag)
       RESULT_VARIABLE nok ERROR_VARIABLE error
       WORKING_DIRECTORY "${GIT_EXTERNAL_DIR}")
     if(nok)
-      message(FATAL_ERROR "${DIR} clone failed: ${error}\n")
+      if(GIT_EXTERNAL_LOCAL_OPTIONAL)
+        message(STATUS "${DIR} clone failed: ${error}\n")
+        return()
+      else()
+        message(FATAL_ERROR "${DIR} clone failed: ${error}\n")
+      endif()
     endif()
 
     # checkout requested tag
@@ -265,7 +273,7 @@ if(EXISTS ${GIT_EXTERNALS} AND NOT GIT_EXTERNAL_SCRIPT_MODE)
         # Create a unique, flat name
         string(REPLACE "/" "-" GIT_EXTERNAL_NAME ${DIR}_${PROJECT_NAME})
 
-        if(NOT TARGET update_git_external_${GIT_EXTERNAL_NAME}) # not done
+        if(NOT TARGET update-gitexternal-${GIT_EXTERNAL_NAME}) # not done
           # pull in identified external
           git_external(${DIR} ${REPO} ${TAG})
 
@@ -273,10 +281,13 @@ if(EXISTS ${GIT_EXTERNALS} AND NOT GIT_EXTERNAL_SCRIPT_MODE)
           if(NOT TARGET update)
             add_custom_target(update)
           endif()
-          if(NOT TARGET update_git_external)
-            add_custom_target(update_git_external)
-            add_custom_target(flatten_git_external)
-            add_dependencies(update update_git_external)
+          if(NOT TARGET update-gitexternal)
+            add_custom_target(update-gitexternal)
+            add_custom_target(flatten-gitexternal)
+            add_dependencies(update update-gitexternal)
+          endif()
+          if(NOT TARGET ${PROJECT_NAME}-flatten-gitexternal)
+            add_custom_target(${PROJECT_NAME}-flatten-gitexternal)
           endif()
 
           # Create a unique, flat name
@@ -284,7 +295,7 @@ if(EXISTS ${GIT_EXTERNALS} AND NOT GIT_EXTERNAL_SCRIPT_MODE)
             ${GIT_EXTERNALS})
           string(REPLACE "/" "_" GIT_EXTERNAL_TARGET ${GIT_EXTERNALS_BASE})
 
-          set(GIT_EXTERNAL_TARGET update_git_external_${GIT_EXTERNAL_TARGET})
+          set(GIT_EXTERNAL_TARGET update-gitexternal-${GIT_EXTERNAL_TARGET})
           if(NOT TARGET ${GIT_EXTERNAL_TARGET})
             set(GIT_EXTERNAL_SCRIPT
               "${CMAKE_CURRENT_BINARY_DIR}/${GIT_EXTERNAL_TARGET}.cmake")
@@ -312,13 +323,13 @@ if(newref)
 else()
   file(APPEND ${GIT_EXTERNALS} \"# ${DIR} ${REPO} ${TAG}\n\")
 endif()")
-          add_custom_target(update_git_external_${GIT_EXTERNAL_NAME}
+          add_custom_target(update-gitexternal-${GIT_EXTERNAL_NAME}
             COMMAND "${CMAKE_COMMAND}" -DGIT_EXTERNAL_SCRIPT_MODE=1 -P ${GIT_EXTERNAL_SCRIPT}
             COMMENT "Update ${REPO} in ${GIT_EXTERNALS_BASE}"
             DEPENDS ${GIT_EXTERNAL_TARGET}
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-          add_dependencies(update_git_external
-            update_git_external_${GIT_EXTERNAL_NAME})
+          add_dependencies(update-gitexternal
+            update-gitexternal-${GIT_EXTERNAL_NAME})
 
           # Flattens a git external repository into its parent repo:
           # * Clean any changes from external
@@ -326,19 +337,21 @@ endif()")
           # * Add external directory to parent
           # * Commit with flattened repo and tag info
           # - Depend on release branch checked out
-          add_custom_target(flatten_git_external_${GIT_EXTERNAL_NAME}
+          add_custom_target(flatten-gitexternal-${GIT_EXTERNAL_NAME}
             COMMAND "${GIT_EXECUTABLE}" clean -dfx
             COMMAND "${CMAKE_COMMAND}" -E remove_directory .git
             COMMAND "${CMAKE_COMMAND}" -E remove -f "${CMAKE_CURRENT_SOURCE_DIR}/.gitexternals"
             COMMAND "${GIT_EXECUTABLE}" add -f .
             COMMAND "${GIT_EXECUTABLE}" commit -m "Flatten ${REPO} into ${DIR} at ${TAG}" . "${CMAKE_CURRENT_SOURCE_DIR}/.gitexternals"
             COMMENT "Flatten ${REPO} into ${DIR}"
-            DEPENDS make_branch_${PROJECT_NAME}
+            DEPENDS ${PROJECT_NAME}-make-branch
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${DIR}")
-          add_dependencies(flatten_git_external
-            flatten_git_external_${GIT_EXTERNAL_NAME})
+          add_dependencies(flatten-gitexternal
+            flatten-gitexternal-${GIT_EXTERNAL_NAME})
+          add_dependencies(${PROJECT_NAME}-flatten-gitexternal
+            flatten-gitexternal-${GIT_EXTERNAL_NAME})
 
-          foreach(_target flatten_git_external_${GIT_EXTERNAL_NAME} flatten_git_external update_git_external_${GIT_EXTERNAL_NAME} ${GIT_EXTERNAL_TARGET} update_git_external update)
+          foreach(_target flatten-gitexternal-${GIT_EXTERNAL_NAME} ${PROJECT_NAME}-flatten-gitexternal flatten-gitexternal update-gitexternal-${GIT_EXTERNAL_NAME} ${GIT_EXTERNAL_TARGET} update-gitexternal update)
             set_target_properties(${_target} PROPERTIES
               EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER git)
           endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ common_package_post()
 set(MONSTEER_DEPENDENT_LIBRARIES Lunchbox zeq)
 
 add_subdirectory(monsteer)
+add_subdirectory(nrp)
 add_subdirectory(apps)
 add_subdirectory(tests)
 add_subdirectory(examples)

--- a/apps/nrp_proxy.cpp
+++ b/apps/nrp_proxy.cpp
@@ -18,9 +18,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "nrp/playbackState_generated.h"
 #include "nrp/steering/vocabulary.h"
-#include "nrp/stimulus_generated.h"
+#include "monsteer/stimulus_generated.h"
 
 #include <brion/spikeReport.h>
 #include <lunchbox/debug.h>
@@ -176,8 +175,8 @@ public:
 
     SteeringHandler( MUSIC::Setup* setup, const std::string& steeringPort, std::string session_name)
         : _proxyState( monsteer::steering::ProxyStatus::READY )
-        , _subscriber( new zeq::Subscriber(std::string("nrp-upstream")) )
-        , _publisher( new zeq::Publisher( std::string("nrp-downstream") ) )
+        , _subscriber( new zeq::Subscriber(zeq::DEFAULT_SESSION) )
+        , _publisher( new zeq::Publisher( zeq::DEFAULT_SESSION ) )
     {
         LBINFO << "Initializing Steering Handler" << std::endl;
 
@@ -243,6 +242,7 @@ private:
 
     void _onStimulusInjection( const zeq::Event& event )
     {
+        LBINFO << "Got injection" << std::endl;
         LBASSERT( event.getType() == monsteer::steering::EVENT_STIMULUSINJECTION )
         const std::string& json = zeq::vocabulary::deserializeJSON( event );
         // Although music library internally "does not" touch the sent data,
@@ -266,18 +266,10 @@ private:
         _requestedSimTime = trigger.duration / 1000;
     }
 
-    void _onPlaybackStateChange( const zeq::Event& event )
-    {
-        LBASSERT( event.getType() == monsteer::steering::EVENT_PLAYBACKSTATE )
-        const monsteer::steering::SimulationPlaybackState& state =
-                monsteer::steering::deserializePlaybackState( event );
-
-        // DO NOTHING
-        //_state = state.state;
-    }
 
     void _onStatusRequest( const zeq::Event& event )
     {
+        LBINFO << "Got status request" << std::endl;
         LBASSERT( event.getType() == monsteer::steering::EVENT_STATUSREQUESTMSG )
             const monsteer::steering::StatusRequest& request = 
                 monsteer::steering::deserializeStatusRequest( event );

--- a/apps/nrp_proxy.cpp
+++ b/apps/nrp_proxy.cpp
@@ -175,8 +175,8 @@ public:
 
     SteeringHandler( MUSIC::Setup* setup, const std::string& steeringPort, std::string session_name)
         : _proxyState( monsteer::steering::ProxyStatus::READY )
-        , _subscriber( new zeq::Subscriber(zeq::DEFAULT_SESSION) )
-        , _publisher( new zeq::Publisher( zeq::DEFAULT_SESSION ) )
+        , _subscriber( new zeq::Subscriber(zeq::URI("nrp-upstream")) )
+        , _publisher( new zeq::Publisher( zeq::URI("nrp-downstream")) )
     {
         LBINFO << "Initializing Steering Handler" << std::endl;
 

--- a/apps/nrp_proxy.cpp
+++ b/apps/nrp_proxy.cpp
@@ -1,0 +1,365 @@
+
+/* Copyright (c) 2006-2015, Ahmet Bilgili <ahmet.bilgili@epfl.ch>
+ *                          Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "nrp/playbackState_generated.h"
+#include "nrp/steering/vocabulary.h"
+#include "nrp/stimulus_generated.h"
+
+#include <brion/spikeReport.h>
+#include <lunchbox/debug.h>
+#include <lunchbox/log.h>
+
+#include <zeq/subscriber.h>
+#include <zeq/publisher.h>
+#include <zeq/vocabulary.h>
+
+#include <music.hh>
+
+#include <boost/bind.hpp>
+#include <boost/program_options.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/scoped_ptr.hpp>
+
+namespace po = boost::program_options;
+
+namespace
+{
+const double defaultMusicTimestep = 0.0001;
+const brion::URI pluginURI( MONSTEER_BRION_SPIKES_PLUGIN_SCHEME + "://" );
+}
+
+class SpikesHandler : public MUSIC::EventHandlerGlobalIndex
+{
+public:
+    SpikesHandler( MUSIC::Setup* setup, const std::string& spikesPort )
+        : _spikeReport( pluginURI, brion::MODE_OVERWRITE )
+    {
+        LBINFO << "Initializing Spikes Handler" << std::endl;
+
+        MPI::Intracomm communicator = setup->communicator();
+        const uint32_t rank = communicator.Get_rank();
+        // Publishing the ports
+        _inSpikes = setup->publishEventInput( spikesPort );
+
+        if( !_inSpikes->isConnected( ))
+        {
+            if( rank == 0 )
+                LBERROR << "Spikes input port is not connected" << std::endl;
+           communicator.Abort( 1 );
+        }
+
+        if( !_inSpikes->hasWidth( ))
+        {
+            if( rank == 0 )
+                LBERROR << "Spikes input port does not have width"
+                        << std::endl;
+           communicator.Abort( 1 );
+        }
+
+        // Mapping the inSpikes port
+        const uint32_t width = _inSpikes->width();
+        _spikesMap.reset(new MUSIC::LinearIndex( 1, width ));
+        _inSpikes->map( _spikesMap.get(), this, 0 );
+
+        LBINFO << "Initialized Spikes Handler" << std::endl;
+    }
+
+    void operator()( double time, MUSIC::GlobalIndex gid ) final
+    {
+        _spikeBuffer.insert( std::make_pair( float( time * 1000 ),
+                                             uint32_t( gid )));
+    }
+
+    void flush()
+    {
+        if (_spikeBuffer.empty())
+            return;
+
+        _spikeReport.writeSpikes( _spikeBuffer );
+        _spikeBuffer.clear();
+    }
+
+private:
+
+    MUSIC::EventInputPort* _inSpikes;
+    brion::SpikeReport _spikeReport;
+    brion::Spikes _spikeBuffer;
+    boost::scoped_ptr< MUSIC::IndexMap > _spikesMap;
+};
+
+class CommandLineOptions
+{
+public:
+    std::string spikesPort;
+    std::string steeringPort;
+    std::string zeqSessionName;
+
+    double musicTimestep;
+
+    CommandLineOptions( int32_t argc, char* argv[] )
+        : musicTimestep( defaultMusicTimestep )
+    {
+        bool showHelp;
+
+        po::options_description options( "MUSIC proxy" );
+
+        options.add_options()
+            ( "help,h", po::bool_switch(&showHelp)->default_value( false ),
+              "produce help message" )
+            ( "timestep",
+              po::value< double >(
+                  &musicTimestep )->default_value( defaultMusicTimestep ),
+              "MUSIC library tick time steps" )
+
+            ( "music-streaming-port",
+              po::value< std::string >(
+                  &spikesPort )->default_value( "spikesPort" ),
+              "MUSIC streaming port" )
+
+            ( "session-name",
+              po::value< std::string >(
+                  &zeqSessionName )->default_value( zeq::DEFAULT_SESSION ),
+              "ZEQ session name" )
+
+            ( "music-steering-port",
+              po::value< std::string >(
+                  &steeringPort )->default_value( "steeringPort" ),
+              "MUSIC steering port" );
+
+        options.add_options();
+
+        po::variables_map variableMap;
+
+        try
+        {
+            // parse program options, ignore all non related options
+            po::store( po::command_line_parser( argc, argv ).options(
+                           options ).allow_unregistered().run(),
+                       variableMap );
+            po::notify( variableMap );
+        }
+        catch( std::exception& exception )
+        {
+            LBERROR << "Error parsing command line: " << exception.what()
+                    << std::endl;
+            ::exit( EXIT_FAILURE );
+        }
+
+        if( showHelp )
+        {
+            std::cout << options << std::endl;
+            ::exit( EXIT_SUCCESS );
+        }
+    }
+};
+
+class SteeringHandler
+{
+public:
+
+    SteeringHandler( MUSIC::Setup* setup, const std::string& steeringPort, std::string session_name)
+        : _proxyState( monsteer::steering::ProxyStatus::READY )
+        , _subscriber( new zeq::Subscriber(std::string("nrp-upstream")) )
+        , _publisher( new zeq::Publisher( std::string("nrp-downstream") ) )
+    {
+        LBINFO << "Initializing Steering Handler" << std::endl;
+
+        _steeringOutput = setup->publishMessageOutput( steeringPort );
+        if( !_steeringOutput->isConnected( ))
+        {
+            if( setup->communicator().Get_rank() == 0 )
+                LBERROR << "Steering port is not connected" << std::endl;
+             setup->communicator().Abort( 1 );
+        }
+
+        _steeringOutput->map();
+
+        _subscriber.registerHandler(
+            monsteer::steering::EVENT_STIMULUSINJECTION,
+            boost::bind( &SteeringHandler::_onStimulusInjection, this, _1 ));
+
+        _subscriber.registerHandler(
+            monsteer::steering::EVENT_RUNSIMTRIGGER,
+            boost::bind( &SteeringHandler::_onSimulationTrigger, this, _1 ));
+
+        _subscriber.registerHandler(
+            monsteer::steering::EVENT_STATUSREQUESTMSG,
+            boost::bind( &SteeringHandler::_onStatusRequest, this, _1 ));
+
+        LBINFO << "Initialized Steering Handler" << std::endl;
+    }
+
+    void processTicks(MUSIC::Runtime & runtime)
+    {
+        _currentTime = runtime.time();
+        if (_requestedSimTime <= 0.0)
+        {
+            SteeringHandler::_setStatus(monsteer::steering::ProxyStatus::READY);
+            _requestedSimTime = 0.0;
+            return;
+        }
+        runtime.tick();
+        _requestedSimTime -= runtime.time() - _currentTime;
+    }
+    
+
+    void processMessages( const double musicTime )
+    {
+
+        _currentTime = musicTime;
+        while( _subscriber.receive( 0 ))
+         ;
+//        switch( _state )
+//        {
+//        case monsteer::steering::SimulationPlaybackState::PLAY:
+//        {
+//            _currentTime = musicTime;
+//            while( _subscriber.receive( 0 ))
+//             ;
+//            break;
+//        }
+//        }
+    }
+
+
+private:
+
+    void _onStimulusInjection( const zeq::Event& event )
+    {
+        LBASSERT( event.getType() == monsteer::steering::EVENT_STIMULUSINJECTION )
+        const std::string& json = zeq::vocabulary::deserializeJSON( event );
+        // Although music library internally "does not" touch the sent data,
+        // the Music "insertMessage" function accepts only non-const data.
+        // Not to have a second copy, the below const_cast is applied.
+        _steeringOutput->insertMessage( _currentTime,
+                                        const_cast<char*>(json.c_str()),
+                                        json.size());
+    }
+
+    void _onSimulationTrigger( const zeq::Event& event )
+    {
+        LBINFO << "Triggered Simulation Run" << std::endl;
+        LBASSERT( event.getType() == monsteer::steering::EVENT_RUNSIMTRIGGER )
+        const monsteer::steering::SimulationRunTrigger& trigger = 
+                monsteer::steering::deserializeSimulationRunTrigger( event );
+
+        SteeringHandler::_setStatus(monsteer::steering::ProxyStatus::BUSY);
+
+        // Convertion to seconds (to match musics runtime.time() output)
+        _requestedSimTime = trigger.duration / 1000;
+    }
+
+    void _onPlaybackStateChange( const zeq::Event& event )
+    {
+        LBASSERT( event.getType() == monsteer::steering::EVENT_PLAYBACKSTATE )
+        const monsteer::steering::SimulationPlaybackState& state =
+                monsteer::steering::deserializePlaybackState( event );
+
+        // DO NOTHING
+        //_state = state.state;
+    }
+
+    void _onStatusRequest( const zeq::Event& event )
+    {
+        LBASSERT( event.getType() == monsteer::steering::EVENT_STATUSREQUESTMSG )
+            const monsteer::steering::StatusRequest& request = 
+                monsteer::steering::deserializeStatusRequest( event );
+
+        _publisher.publish( monsteer::steering::serializeProxyStatus(request.messageID, _proxyState ));
+    }
+
+    void _setStatus(monsteer::steering::ProxyStatus::State status)
+    {
+        _proxyState = status;
+        _publisher.publish( monsteer::steering::serializeProxyStatus("", status));
+    }
+
+    zeq::Subscriber _subscriber;
+    zeq::Publisher _publisher;
+    MUSIC::MessageOutputPort* _steeringOutput;
+    double _currentTime;
+    double _requestedSimTime = -1.0;
+    monsteer::steering::ProxyStatus::State _proxyState;
+};
+
+class Proxy : boost::noncopyable
+{
+public:
+
+    // Application command line parsing ( CommandLineOptions() initialization )
+    // must go after MUSIC::Setup because it modifies argc and argv to bring
+    // in the application arguments from the config file.
+    Proxy( int32_t& argc, char**& argv )
+        : _setup( new MUSIC::Setup( argc, argv ))
+        , _communicator( _setup->communicator( ))
+        , _rank( _communicator.Get_rank( ))
+        , _options( argc, argv )
+        , _spikesHandler( _setup, _options.spikesPort )
+    {
+        _steeringHandler.reset(
+                    new SteeringHandler( _setup, _options.steeringPort, _options.sessionName ));
+
+        _setup->config( "stoptime", &_stoptime );
+    }
+
+    void run()
+    {
+        LBINFO << "Starting MUSIC runtime" << std::endl;
+        MUSIC::Runtime runtime( _setup, _options.musicTimestep );
+        // The constructor has called delete _setup.
+        _setup = 0;
+
+        LBVERB << "Application loop" << std::endl;
+
+        double apptime = runtime.time();
+        while( apptime < _stoptime )
+        {
+
+            _steeringHandler->processMessages(apptime);
+            _steeringHandler->processTicks(runtime);
+
+            _spikesHandler.flush();
+            apptime = runtime.time();
+        }
+
+        runtime.finalize();
+    }
+
+private:
+    // MUSIC and MPI handlers
+    MUSIC::Setup* _setup; // Implictly deleted by the _runtime object
+    MPI::Intracomm _communicator;
+    uint32_t _rank;
+
+    CommandLineOptions _options;
+
+    double _stoptime;
+
+    // Internal data structures
+    SpikesHandler _spikesHandler;
+    boost::scoped_ptr< SteeringHandler > _steeringHandler;
+};
+
+int32_t main( int32_t argc, char* argv[] )
+{
+    Proxy proxy( argc, argv );
+    proxy.run();
+    return EXIT_SUCCESS;
+}

--- a/apps/nrp_proxy.cpp
+++ b/apps/nrp_proxy.cpp
@@ -175,8 +175,8 @@ public:
 
     SteeringHandler( MUSIC::Setup* setup, const std::string& steeringPort, std::string session_name)
         : _proxyState( monsteer::steering::ProxyStatus::READY )
-        , _subscriber( new zeq::Subscriber(zeq::URI("nrp-upstream")) )
-        , _publisher( new zeq::Publisher( zeq::URI("nrp-downstream")) )
+        , _subscriber( new zeq::Subscriber("nrp"))
+        , _publisher( new zeq::Publisher( "nrp") )
     {
         LBINFO << "Initializing Steering Handler" << std::endl;
 

--- a/apps/nrp_proxy.cpp
+++ b/apps/nrp_proxy.cpp
@@ -207,15 +207,18 @@ public:
 
     void processTicks(MUSIC::Runtime & runtime)
     {
+        if (_requestedSimTime <= 0.0)
+            return;
+
         _currentTime = runtime.time();
+        runtime.tick();
+        _requestedSimTime -= runtime.time() - _currentTime;
+
         if (_requestedSimTime <= 0.0)
         {
             SteeringHandler::_setStatus(monsteer::steering::ProxyStatus::READY);
             _requestedSimTime = 0.0;
-            return;
         }
-        runtime.tick();
-        _requestedSimTime -= runtime.time() - _currentTime;
     }
     
 
@@ -225,6 +228,7 @@ public:
         _currentTime = musicTime;
         while( _subscriber.receive( 0 ))
          ;
+        LBINFO << "Processed messages" << std::endl;
 //        switch( _state )
 //        {
 //        case monsteer::steering::SimulationPlaybackState::PLAY:

--- a/examples/nest/nest2music_proxy_with_steering.music
+++ b/examples/nest/nest2music_proxy_with_steering.music
@@ -24,5 +24,5 @@ stoptime=10000000
   args=--steering
   np=1
 
-from.spikes_out -> to.spikesPort [1000]
+from.spikes_out -> to.spikesPort [10000000]
 to.steeringPort -> from.steering_input [0]

--- a/nrp/CMakeLists.txt
+++ b/nrp/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2011-2015, Daniel.Nachbaur@epfl.ch
+#
+# This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+#
+
+source_group(\\ FILES CMakeLists.txt)
+
+set(NRP_PUBLIC_HEADERS)
+set(NRP_SOURCES)
+
+include_directories(BEFORE SYSTEM ${PROJECT_BINARY_DIR}/nrp)
+
+#include(streaming/files.cmake)
+include(steering/files.cmake)
+#include(qt/files.cmake)
+
+set(NRP_LINK_LIBRARIES PUBLIC Brion Lunchbox zeq)
+
+common_library(Nrp)
+
+#add_subdirectory(plugin)
+add_subdirectory(python)

--- a/nrp/python/CMakeLists.txt
+++ b/nrp/python/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2011-2015, ahmet.bilgili@epfl.ch
+#
+# This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+#
+
+add_subdirectory(bindings)
+
+configure_file(__init__.py
+               ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/nrp/__init__.py)
+
+install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/nrp/__init__.py
+        DESTINATION ${PYTHON_LIBRARY_SUFFIX}/nrp)
+
+install(FILES Nesteer.py
+        DESTINATION ${PYTHON_LIBRARY_SUFFIX}/nrp)
+
+# Enables doing tests without "make install"
+configure_file(Nesteer.py ${CMAKE_BINARY_DIR}/lib/nrp/Nesteer.py)
+

--- a/nrp/python/Nesteer.py
+++ b/nrp/python/Nesteer.py
@@ -1,0 +1,202 @@
+##
+## Monsteer
+## This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+##
+## contact: ahmet.bilgili@epfl.ch
+##          jafet.villafrancadiaz@epfl.ch
+
+
+import nrp as _nrp
+
+from six.moves import cPickle as _pickle
+import itertools as _itertools
+import json as _json
+import nest as _nest
+import numpy as _numpy
+import os.path
+import sys as _sys
+
+
+def _apply_generators_to_neurons(generators, neurons):
+    """
+    Connect the spike generators to the neurons
+    """
+    print('Stimulus injected to cells: ' + str(neurons[0:10]) + (
+                                         ' ...' if len(neurons) > 10 else ''))
+    print('Stimulus: ' + str(_nest.GetStatus([generators[0]])))
+
+    # If only one generator is present, connect it to all the neurons,
+    # if more than one, it means that there is a different one for each cell
+    if len(generators) == 1:
+        _nest.Connect([generators[0]], neurons, 'all_to_all')
+    elif len(generators) > 1:
+        assert(len(generators) == len(neurons))
+        _nest.Connect(generators, neurons, 'one_to_one')
+
+
+class JSONEncoder(_json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, _nest.pynestkernel.SLILiteral):
+            return [obj.name]
+        if isinstance(obj, _numpy.ndarray) and obj.ndim == 1:
+            return obj.tolist()
+        return _json.JSONEncoder.default(self, obj)
+
+
+class Simulator(_nrp.Simulator):
+    """
+    Class to create a NEST specific simulator proxy using the parent class from
+    Monsteer. It hides details that are irrelevant for users, such as the
+    json_enconder parameter.
+    """
+    def __init__(self, uri):
+        self.simulator = _nrp.Simulator(uri)
+
+    def injectStimulus(self, params, cells):
+        """
+        injectStimulus((Simulator)arg1, (dict)arg2, (Cell_Target)arg3) -> None
+        """
+        self.simulator.injectStimulus(params, cells, json_encoder=JSONEncoder)
+
+    def injectMultipleStimuli(self, params, cells):
+        """
+        injectMultipleStimuli((Simulator)arg1, (dict)arg2, (Cell_Target)arg3) -> None
+        """
+        self.simulator.injectMultipleStimuli(params, cells,
+                                             json_encoder=JSONEncoder)
+
+
+    def play(self):
+        """
+        Plays/Resumes the simulation
+        """
+        self.simulator.play()
+
+
+    def pause(self):
+        """
+        Pauses the simulation
+        """
+        self.simulator.pause()
+
+
+    def simulate(self, duration):
+        """
+        Runs the simulator for the given amount of time in milliseconds.
+        """
+        self.simulator.simulate(duration)
+
+        
+        
+
+
+class Nesteer:
+    """
+    The ISC communication class that handles MUSIC event ports for streaming
+    spikes and message ports for steering input.
+    """
+    def __init__(self, spike_port_name, steering_port_name, neurons, gids, max_music_channel):
+       self._spike_port_name = spike_port_name
+       self._steering_port_name = steering_port_name
+       self._apply_generators_to_neurons_function = _apply_generators_to_neurons
+       self._generator_dict = {}
+       self._gid_to_neuron_map = {}
+       self._event_function_dict = {}
+       self._max_music_channel = max_music_channel
+
+       for (neuron, gid) in zip(neurons, gids):
+            #status = _nest.GetStatus([neuron])
+            #global_id = status[0]['global_id']
+            global_id = neuron
+            self._gid_to_neuron_map[gid] = global_id
+
+       self._setup_music()
+
+    def process_events(self):
+        """
+        Processes incoming events from steering port
+        """
+        event = _nest.GetStatus(self._music_steering_input, 'data')
+        messages = event[0]['messages']
+        if len(messages) == 0:
+            return
+
+        for message in messages:
+            event_dict = _json.loads(message)
+            if event_dict['eventType'] == 'EVENT_STIMULUSINJECTION':
+                params_dict = _json.loads(event_dict['params'])
+                self._apply_generators_to_neurons(event_dict['messageID'],
+                                                  params_dict,
+                                                  event_dict['cells'],
+                                                  event_dict['multiple'])
+
+        # Clear messages
+        _nest.SetStatus(self._music_steering_input, {'n_messages':0})
+
+    def _apply_generators_to_neurons(self, uuid, parameters, gids, multiple):
+        """
+        Creates the generator(s), sets status and does the mapping
+        between gids and nest neurons.
+        """
+        generator_name = str(parameters['model'][0])
+        del parameters['model'] # Removed to avoid a spurious exception
+        generators = _nest.Create(generator_name, len(gids) if multiple else 1)
+        try:
+            # Coercing numeric parameter types to avoid errors
+            defaults = _nest.GetDefaults(generator_name)
+            for key, value in parameters.items():
+                value_type = type(defaults[key])
+                type_name = value_type.__name__
+                if type_name == 'int' or type_name == 'float':
+                    parameters[key] = value_type(value)
+            _nest.SetStatus(generators, parameters)
+        except _nest.pynestkernel.NESTError as e:
+            if 'DictError' not in str(e):
+                print(e)
+
+        self._generator_dict[uuid] = generators
+
+        neurons = []
+        for gid in gids:
+            neurons.append(self._gid_to_neuron_map[gid])
+
+        self._apply_generators_to_neurons_function(generators, neurons)
+
+    def set_apply_generators_to_neurons_function(self, function):
+        """
+        Users can have their own function for event for applying generators
+        to their circuit.
+        """
+        self._apply_generators_to_neurons_function = function
+
+    def _setup_music(self):
+        """
+        Setup music connection.
+        """
+        _nest.sli_run('statusdict/have_music ::')
+        if not _nest.spp():
+            print('NEST was not compiled with support for MUSIC, not running.')
+            _sys.exit()
+
+        # Setup music spike output.
+        self._music_spike_output = _nest.Create('music_event_out_proxy', 1)
+        _nest.SetStatus(self._music_spike_output,
+                        {'port_name': self._spike_port_name})
+
+        # Connecting neurons to music event channels. In case of the BBP
+        # circuit, each channel corresponds to a gid.
+        for gid, neuron in self._gid_to_neuron_map.items():
+            _nest.Connect([neuron], self._music_spike_output, 'one_to_one',
+                          {'music_channel':   gid})
+
+        # Connecting the last music channel (value specified in the
+        # configuration file) to a dummy neuron
+        dummy = _nest.Create('iaf_neuron', 1)
+        _nest.Connect(dummy, self._music_spike_output, 'one_to_one',
+                      {'music_channel': self._max_music_channel})
+
+        # Setup music steering input.
+        self._music_steering_input = _nest.Create('music_message_in_proxy', 1)
+        _nest.SetStatus(self._music_steering_input,
+                        {'port_name': self._steering_port_name,
+                         'acceptable_latency': 40.0})

--- a/nrp/python/__init__.py
+++ b/nrp/python/__init__.py
@@ -1,0 +1,50 @@
+##
+## Monsteer
+## This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+##
+## contact: ahmet.bilgili@epfl.ch
+##          jafet.villafrancadiaz@epfl.ch
+##          jhernando@fi.upm.es
+
+import sys as _sys
+
+if _sys.version_info[0] != ${USE_PYTHON_VERSION}:
+    raise ImportError("Invalid Python version")
+
+from ._nrp import *
+
+# Monkey patching Simulator.injectStimulus and Stimulus.injectMultipleStimuli
+# to accept a dictionary as input parameter instead of a string
+import json as _json
+import functools as _functools
+
+Simulator._injectStimulus = Simulator.injectStimulus
+Simulator._injectMultipleStimuli = Simulator.injectMultipleStimuli
+
+def _dictToString(dict, json_encoder):
+    return (_json.dumps(dict) if json_encoder is None
+            else _json.dumps(dict, cls=json_encoder))
+
+def _simulator_inject_stimulus(self, parameters, cell_ids,
+                               json_encoder = None):
+    """injectStimulus( (Simulator)arg1, (dict)arg2, (cell_ids)arg3, (JSONEncoder)arg4) -> None
+    """
+    parameters = _dictToString(parameters, json_encoder)
+    return Simulator._injectStimulus(self, parameters, cell_ids)
+
+def _simulator_inject_multiple_stimuli(self, parameters, cell_ids,
+                                       json_encoder = None):
+    """injectMultipleStimuli( (Simulator)arg1, (dict)arg2, (cell_ids)arg3, (JSONEncoder)arg4) -> None
+    """
+    parameters = _dictToString(parameters, json_encoder)
+    return Simulator._injectMultipleStimuli(self, parameters, cell_ids)
+
+
+_functools.update_wrapper(_simulator_inject_stimulus, Simulator.injectStimulus,
+                          assigned=('__name__', '__module__'))
+_functools.update_wrapper(_simulator_inject_multiple_stimuli,
+                          Simulator.injectMultipleStimuli,
+                          assigned=('__name__', '__module__'))
+
+Simulator.injectStimulus = _simulator_inject_stimulus
+Simulator.injectMultipleStimuli = _simulator_inject_multiple_stimuli

--- a/nrp/python/bindings/CMakeLists.txt
+++ b/nrp/python/bindings/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2011-2015, ahmet.bilgili@epfl.ch
+#
+# This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+#
+
+# SOURCES ---------------------------------------------------------------------
+
+set(NRP_PYTHON_BINDING_FILES
+  simulator.cpp
+)
+
+# fix for huge python wrapping running out of memory
+if(MSVC)
+  set_source_files_properties(
+    nrp.cpp
+    PROPERTIES COMPILE_FLAGS "${WARNING_FLAGS} /bigobj /wd4996")
+endif()
+
+
+# TARGETS ---------------------------------------------------------------------
+
+set(NRP_PYTHON_SOURCE_FILES
+  nrp.cpp
+  ${NRP_PYTHON_BINDING_FILES})
+
+include_directories(${PYTHON_INCLUDE_DIRS})
+add_library(nrp_python MODULE ${NRP_PYTHON_SOURCE_FILES})
+add_dependencies(nrp_python Nrp)
+
+target_link_libraries(nrp_python
+    Nrp ${PYTHON_LIBRARIES}
+     ${Boost_PYTHON${USE_BOOST_PYTHON_VERSION}_LIBRARY})
+
+set_target_properties(nrp_python PROPERTIES
+  OUTPUT_NAME "_nrp" PREFIX ""
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/nrp)
+
+set_property(GLOBAL APPEND PROPERTY MONSTEER_ALL_DEP_TARGETS nrp_python)
+
+# INSTALL --------------------------------------------------------------------
+
+install(TARGETS nrp_python
+  LIBRARY DESTINATION ${PYTHON_LIBRARY_SUFFIX}/nrp)

--- a/nrp/python/bindings/nrp.cpp
+++ b/nrp/python/bindings/nrp.cpp
@@ -1,0 +1,32 @@
+
+/* Copyright (c) 2006-2015, Ahmet Bilgili <ahmet.bilgili@epfl.ch>
+ *                          Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef _MSC_VER
+#pragma warning(disable:4127)
+#endif
+
+#include <boost/python.hpp>
+
+#include "simulator.h"
+
+BOOST_PYTHON_MODULE(_nrp)
+{
+    export_Simulator();
+}

--- a/nrp/python/bindings/simulator.cpp
+++ b/nrp/python/bindings/simulator.cpp
@@ -1,0 +1,81 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <boost/python.hpp>
+
+#include "nrp/steering/simulator.h"
+
+#include <lunchbox/uri.h>
+
+#include <boost/python/stl_iterator.hpp>
+
+using namespace monsteer;
+using namespace boost::python;
+
+
+void Simulator_injectStimulus( monsteer::Simulator& simulator,
+                               const std::string& json,
+                               object list )
+{
+    brion::uint32_ts ids;
+    ids.reserve( len( list ) );
+    stl_input_iterator< uint32_t > i(list), end;
+    while( i != end )
+        ids.push_back( *i++ );
+    simulator.injectStimulus( json, ids );
+}
+
+void Simulator_injectMultipleStimuli( monsteer::Simulator& simulator,
+                                      const std::string& json,
+                                      object list )
+{
+    brion::uint32_ts ids;
+    ids.reserve( len( list ));
+    stl_input_iterator< uint32_t > i( list ), end;
+    while( i != end )
+        ids.push_back( *i++ );
+    simulator.injectMultipleStimuli( json, ids );
+}
+
+void Simulator_simulate( monsteer::Simulator& simulator, 
+                                      const double duration )
+{
+    simulator.simulate( duration );
+}
+
+
+SimulatorPtr Simulator_init( const std::string& uri )
+{
+    return SimulatorPtr(new Simulator( lunchbox::URI( uri )));
+}
+
+
+void export_Simulator()
+{
+    //register_exception_translator<TimeoutException>(&timeout_exception_translator);
+
+    class_< Simulator, boost::noncopyable >( "Simulator", no_init )
+        .def( "__init__", make_constructor( Simulator_init ))
+        .def( "injectStimulus", Simulator_injectStimulus, arg( "json" ))
+        .def( "injectMultipleStimuli",
+              Simulator_injectMultipleStimuli, arg( "json" ))
+        .def( "simulate", &Simulator::simulate )
+    ;
+}
+

--- a/nrp/python/bindings/simulator.h
+++ b/nrp/python/bindings/simulator.h
@@ -1,0 +1,25 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef NRP_BINDING_SIMULATOR_H
+#define NRP_BINDING_SIMULATOR_H
+
+void export_Simulator();
+
+#endif

--- a/nrp/steering/files.cmake
+++ b/nrp/steering/files.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2011-2015, Juan Hernando <jhernando@fi.upm.es>
+#
+# This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+#
+
+
+flatbuffers_generate_c_headers(NRP_STEERING_FB steering/proxyStatusMsg.fbs
+                                           steering/runSimTrigger.fbs
+                                           steering/statusRequestMsg.fbs)
+                                        
+
+list(APPEND NRP_PUBLIC_HEADERS
+   steering/simulator.h
+   steering/simulatorPlugin.h)
+
+list(APPEND NRP_HEADERS
+    ${NRP_STEERING_FB_ZEQ_OUTPUTS}
+  steering/vocabulary.h
+  steering/plugin/nestSimulator.h)
+
+list(APPEND NRP_SOURCES
+  steering/simulator.cpp
+  steering/vocabulary.cpp
+  steering/plugin/nestSimulator.cpp)

--- a/nrp/steering/plugin/nestSimulator.cpp
+++ b/nrp/steering/plugin/nestSimulator.cpp
@@ -1,0 +1,137 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "nestSimulator.h"
+
+#include <monsteer/types.h>
+#include <nrp/steering/vocabulary.h>
+#include <monsteer/steering/vocabulary.h>
+
+#include <zeq/subscriber.h>
+#include <zeq/publisher.h>
+#include <zeq/uri.h>
+
+#include <lunchbox/debug.h>
+#include <lunchbox/pluginRegisterer.h>
+
+#include <iostream>
+
+#include <chrono>
+
+namespace monsteer
+{
+namespace steering
+{
+
+namespace
+{
+lunchbox::PluginRegisterer< NESTSimulator > registerer;
+}
+
+NESTSimulator::NESTSimulator( const SimulatorPluginInitData& pluginData )
+    : _replySubscriber( new zeq::Subscriber( std::string("nrp-downstream") ) )
+    , _requestPublisher( new zeq::Publisher( std::string("nrp-upstream") ) )
+                                            
+{
+}
+
+bool NESTSimulator::handles( const SimulatorPluginInitData& pluginData )
+{
+    return pluginData.subscriber.getScheme() ==
+                      MONSTEER_NEST_SIMULATOR_PLUGIN_SCHEME;
+}
+
+void NESTSimulator::barrier()
+{
+    uint32_t attempt = 1;
+    const uint32_t timeout = 1000;
+    const uint32_t max_attempts = 10;
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    while (_proxyState != monsteer::steering::ProxyStatus::State::READY)
+    //_replySubscriber->receive(0);
+    {
+        while(_replySubscriber->receive(0));
+        if ( attempt > max_attempts )
+            throw std::runtime_error("Monsteer-steering had a timeout.");
+        const auto endTime = std::chrono::high_resolution_clock::now();
+        const uint32_t elapsed =
+            std::chrono::nanoseconds( endTime - startTime ).count() /
+            1000000;
+        if( elapsed > timeout )
+            if(_proxyState != monsteer::steering::ProxyStatus::State::READY )
+            {
+                _requestPublisher->publish(
+                        serializeStatusRequest( std::to_string(++_lastRequestID) ));
+                startTime = std::chrono::high_resolution_clock::now();
+                attempt ++;
+            }
+    }
+}
+
+void NESTSimulator::injectStimulus( const std::string& jsonParameters,
+                                    const brion::uint32_ts& cells )
+{
+    // The messageID is irrelevant for the moment
+    _requestPublisher->publish(
+        serializeStimulus( "", cells, jsonParameters, /*single*/ false ));
+}
+
+void NESTSimulator::injectMultipleStimuli( const std::string& jsonParameters,
+                                           const brion::uint32_ts& cells )
+{
+    // The messageID is irrelevant for the moment
+    _requestPublisher->publish(
+        serializeStimulus( "", cells, jsonParameters, /*multiple*/ true ));
+}
+
+void NESTSimulator::play()
+{
+}
+
+
+void NESTSimulator::pause()
+{
+}
+
+void NESTSimulator::simulate( const double duration)
+{
+    //_requestPublisher->publish(
+     //   serializePlaybackState( "", SimulationPlaybackState::ONDEMAND ));
+    //_replySubscriber->receive(0);
+    
+    barrier();
+    _proxyState = monsteer::steering::ProxyStatus::State::BUSY;
+    _requestPublisher->publish(
+            serializeSimulationRunTrigger( "", duration ));
+    barrier();
+}
+
+
+void NESTSimulator::_onProxyStatusUpdate( const zeq::Event& event )  
+{
+    LBASSERT( event.getType() == EVENT_PROXYSTATUSMSG ); 
+    const monsteer::steering::ProxyStatus& state = 
+        monsteer::steering::deserializeProxyStatus( event );
+    _proxyState = state.state;
+}
+
+
+}
+}

--- a/nrp/steering/plugin/nestSimulator.cpp
+++ b/nrp/steering/plugin/nestSimulator.cpp
@@ -44,8 +44,8 @@ lunchbox::PluginRegisterer< NESTSimulator > registerer;
 }
 
 NESTSimulator::NESTSimulator( const SimulatorPluginInitData& pluginData )
-    : _replySubscriber( new zeq::Subscriber( zeq::URI("nrp-downstream") ))
-    , _requestPublisher( new zeq::Publisher(  zeq::URI("nrp-upstream" )) )
+    : _replySubscriber( new zeq::Subscriber( "nrp" ))
+    , _requestPublisher( new zeq::Publisher( "nrp" ))
                                             
 {
       _replySubscriber->registerHandler(EVENT_PROXYSTATUSMSG, boost::bind( &NESTSimulator::_onProxyStatusUpdate, this, _1 )); 

--- a/nrp/steering/plugin/nestSimulator.cpp
+++ b/nrp/steering/plugin/nestSimulator.cpp
@@ -44,8 +44,8 @@ lunchbox::PluginRegisterer< NESTSimulator > registerer;
 }
 
 NESTSimulator::NESTSimulator( const SimulatorPluginInitData& pluginData )
-    : _replySubscriber( new zeq::Subscriber(  zeq::DEFAULT_SESSION ) )
-    , _requestPublisher( new zeq::Publisher(  zeq::DEFAULT_SESSION ) )
+    : _replySubscriber( new zeq::Subscriber( zeq::URI("nrp-downstream") ))
+    , _requestPublisher( new zeq::Publisher(  zeq::URI("nrp-upstream" )) )
                                             
 {
       _replySubscriber->registerHandler(EVENT_PROXYSTATUSMSG, boost::bind( &NESTSimulator::_onProxyStatusUpdate, this, _1 )); 

--- a/nrp/steering/plugin/nestSimulator.cpp
+++ b/nrp/steering/plugin/nestSimulator.cpp
@@ -113,11 +113,13 @@ void NESTSimulator::injectMultipleStimuli( const std::string& jsonParameters,
 
 void NESTSimulator::play()
 {
+    throw std::runtime_error("Not supported");
 }
 
 
 void NESTSimulator::pause()
 {
+    throw std::runtime_error("Not supported");
 }
 
 void NESTSimulator::simulate( const double duration)
@@ -128,6 +130,7 @@ void NESTSimulator::simulate( const double duration)
     
     barrier();
     _proxyState = monsteer::steering::ProxyStatus::State::BUSY;
+    std::cout << "Send SimulationTrigger" << std::endl;
     _requestPublisher->publish(
             serializeSimulationRunTrigger( "", duration ));
     barrier();

--- a/nrp/steering/plugin/nestSimulator.h
+++ b/nrp/steering/plugin/nestSimulator.h
@@ -62,7 +62,7 @@ private:
     boost::scoped_ptr< zeq::Subscriber > _replySubscriber;
     boost::scoped_ptr< zeq::Publisher > _requestPublisher;
     monsteer::steering::ProxyStatus::State _proxyState;
-    uint32_t _lastRequestID = 1;
+    uint32_t _lastReceivedStatusID = 0;
     uint32_t _lastAcknowledgeID = 0;
 
     /** @copydoc monsteer::Simulator::_onProxyStatusUpdate */

--- a/nrp/steering/plugin/nestSimulator.h
+++ b/nrp/steering/plugin/nestSimulator.h
@@ -1,0 +1,79 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef NRP_PLUGIN_NESTSIMULATOR_H
+#define NRP_PLUGIN_NESTSIMULATOR_H
+
+#include <nrp/steering/simulatorPlugin.h>
+#include <lunchbox/uri.h>
+#include <boost/scoped_ptr.hpp>
+#include <nrp/steering/vocabulary.h>
+
+namespace monsteer
+{
+namespace steering
+{
+
+/** Steering interface to NEST simulations */
+class NESTSimulator : public monsteer::SimulatorPlugin
+{
+public:
+    explicit NESTSimulator( const SimulatorPluginInitData& pluginData );
+
+    /** Check if this plugin can handle the given plugin data. */
+    static bool handles( const SimulatorPluginInitData& pluginData );
+
+    /** @copydoc monsteer::Simulator::injectStimulus */
+    void injectStimulus( const std::string& jsonParameters,
+                         const brion::uint32_ts& cells ) final;
+
+    /** @copydoc monsteer::Simulator::injectMultipleStimuli */
+    void injectMultipleStimuli( const std::string& jsonParameters,
+                                const brion::uint32_ts& cells ) final;
+
+    /** @copydoc monsteer::Simulator::play */
+    void play() final;
+
+    /** @copydoc monsteer::Simulator::pause */
+    void pause() final;
+
+    /** @copydoc monsteer::Simulator::simulate*/
+    void simulate( const double duration ) final;
+
+
+
+private:
+    boost::scoped_ptr< zeq::Subscriber > _replySubscriber;
+    boost::scoped_ptr< zeq::Publisher > _requestPublisher;
+    monsteer::steering::ProxyStatus::State _proxyState;
+    uint32_t _lastRequestID = 1;
+    uint32_t _lastAcknowledgeID = 0;
+
+    /** @copydoc monsteer::Simulator::_onProxyStatusUpdate */
+    void _onProxyStatusUpdate( const zeq::Event& event );
+
+    /** @copydoc monsteer::Simulator::barrier */
+
+    void barrier();
+};
+
+}
+}
+#endif
+

--- a/nrp/steering/proxyStatusMsg.fbs
+++ b/nrp/steering/proxyStatusMsg.fbs
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, EPFL/Blue Brain Project
+//                     Jafet Villafranca Diaz <jafet.villafrancadiaz@epfl.ch>
+//
+// Copyright (c) 2015, FZI/Human Brain Project
+//                     Martin Asghar Schulze <schulze@fzi.de>
+//
+namespace monsteer.steering;
+
+table ProxyStatusMsg
+{
+  messageID:string;
+  state:uint;
+}
+
+root_type ProxyStatusMsg;

--- a/nrp/steering/runSimTrigger.fbs
+++ b/nrp/steering/runSimTrigger.fbs
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, EPFL/Blue Brain Project
+//                     Jafet Villafranca Diaz <jafet.villafrancadiaz@epfl.ch>
+//
+// Copyright (c) 2015, FZI/Human Brain Project
+//                     Martin Asghar Schulze <schulze@fzi.de>
+//
+namespace monsteer.steering;
+
+table RunSimTrigger 
+{
+  messageID:string;
+  duration:double;
+}
+
+root_type RunSimTrigger;

--- a/nrp/steering/simulator.cpp
+++ b/nrp/steering/simulator.cpp
@@ -1,0 +1,86 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "simulator.h"
+#include "simulatorPlugin.h"
+
+#include <lunchbox/plugin.h>
+#include <lunchbox/pluginFactory.h>
+#include <boost/scoped_ptr.hpp>
+
+namespace monsteer
+{
+
+class Simulator::Impl
+{
+public:
+    typedef lunchbox::PluginFactory<
+        SimulatorPlugin, SimulatorPluginInitData > SimulatorPluginFactory;
+
+    explicit Impl( const SimulatorPluginInitData& initData )
+        : plugin( SimulatorPluginFactory::getInstance().create( initData ))
+    {
+    }
+
+    boost::scoped_ptr< SimulatorPlugin > plugin;
+};
+
+
+Simulator::Simulator( const URI& uri )
+    // The publisher URI is the scheme part of the subscriber URI for the
+    // moment.
+    : _impl( new Simulator::Impl( SimulatorPluginInitData( uri )))
+{
+}
+
+Simulator::~Simulator()
+{
+    delete _impl;
+}
+
+void Simulator::injectStimulus( const std::string& jsonParameters,
+                                const brion::uint32_ts& cells )
+{
+    _impl->plugin->injectStimulus( jsonParameters, cells );
+}
+
+void Simulator::injectMultipleStimuli( const std::string& jsonParameters,
+                                       const brion::uint32_ts& cells )
+{
+    _impl->plugin->injectMultipleStimuli( jsonParameters, cells );
+}
+
+
+void Simulator::play()
+{
+    _impl->plugin->play();
+}
+
+void Simulator::pause()
+{
+    _impl->plugin->pause();
+}
+
+void Simulator::simulate( const double duration )
+{
+    _impl->plugin->simulate( duration );
+}
+
+
+}

--- a/nrp/steering/simulator.h
+++ b/nrp/steering/simulator.h
@@ -1,0 +1,133 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <monsteer/types.h>
+#include <boost/noncopyable.hpp>
+
+namespace monsteer
+{
+
+/** Steering interface to the simulator of an experiment.
+ *
+ * This class provides access to the simulator engine for computational
+ * steering.
+ *
+ * The implementation is chosen automatically based on the URI that locates
+ * the simulator in the network.
+ *
+ * @version 0.2
+ */
+class Simulator : public boost::noncopyable
+{
+public:
+    /**
+     * Create a simulator using the input URI as the location of the simulation
+     * reply publisher.
+     * The URI for the steering request publisher is derived from the input URI.
+     *
+     * @param uri A subscriber URI to listen to reply events.
+     * @param uri B publisher URI to create steering events.
+     * @throw std::runtime_error if the input URI is not handled by any
+     *        registered simulator steering plugin
+     * @version 0.2
+     */
+
+    explicit Simulator( const URI& uri);
+
+    ~Simulator();
+
+    /**
+     * Attach a stimulus generator to a list of cells.
+     *
+     * A stimulus generator is created on the simulation side using the
+     * parameters provided. The stimulus source is connected to all cells
+     * at the moment it is received by the simulator.
+     *
+     * This operation may fail silently in the current implementation.
+     *
+     * @throw std::runtime_error if an error is detected in generator
+     * parameters
+     * @version 0.2
+     */
+    void injectStimulus( const std::string& jsonParameters,
+                         const brion::uint32_ts& cells );
+
+
+    /**
+     * Attach multiple stimulus generators to a list of cells.
+     *
+     * Multiple stimulus generators (as many as cells) are created on the
+     * simulation side using the parameters provided.
+     * Each of the stimulus sources is connected to a different cell at the
+     * moment they are received by the simulator.
+     *
+     * This operation may fail silently in the current implementation.
+     *
+     * @throw std::runtime_error if an error is detected in generator
+     * parameters
+     * @version 0.2
+     */
+    void injectMultipleStimuli( const std::string& jsonParameters,
+                                const brion::uint32_ts& cells );
+
+    /*
+     * Resumes/plays the simulation.
+     *
+     * The synchronization policies are defined by each simulation engine and
+     * plugin. The only guarantee provided is that if the timestamp that is
+     * externally visible at any given moment is x and, the simulation will
+     * be stopped at time y >= x with no additional guarantee about
+     * the difference between y and x.
+     *
+     * Does not check the current playback state of the simulation.
+     *
+     * @version 0.2
+     *
+     */
+    void play();
+
+    /*
+     * Pauses the simulation.
+     *
+     * Does not check the current playback state of the simulation.
+     *
+     * @version 0.2
+     *
+     */
+    void pause();
+
+    /*
+     * Runs the simulation for a fixed duration.
+     *
+     * The specified duration applies only to the internal music-timer in the 
+     * HBP music proxy application. The same restrictions as with play() apply.
+     *
+     * @version 0.3
+     *
+     *
+     */
+    void simulate( const double duration );
+
+
+private:
+    class Impl;
+    Impl* _impl;
+};
+
+}

--- a/nrp/steering/simulatorPlugin.h
+++ b/nrp/steering/simulatorPlugin.h
@@ -1,0 +1,85 @@
+
+/* Copyright (c) 2006-2015, Juan Hernando <jhernando@fi.upm.es>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef NRP_SIMULATORPLUGIN_H
+#define NRP_SIMULATORPLUGIN_H
+
+#include <monsteer/types.h>
+
+namespace monsteer
+{
+
+/** Init data for SimulatorPlugin
+ * @version 0.4
+ */
+class SimulatorPluginInitData
+{
+public:
+    explicit SimulatorPluginInitData( const URI& subscriber_ )
+        : subscriber( subscriber_ )
+    {
+    }
+
+    const URI subscriber;
+};
+
+/** Base interface for simulator steering plugins
+ *
+ * @version 0.2
+ */
+class SimulatorPlugin : public boost::noncopyable
+{
+public:
+    /** @internal Needed by the PluginRegisterer. */
+    typedef SimulatorPlugin PluginT;
+
+    /** @internal Needed by the PluginRegisterer. */
+    typedef SimulatorPluginInitData InitDataT;
+
+    virtual ~SimulatorPlugin() {}
+
+    /** @copydoc Simulator::injectStimulus */
+    virtual void injectStimulus( const std::string& jsonParameters,
+                                 const brion::uint32_ts& cells ) = 0;
+
+    /** @copydoc Simulator::injectMultipleStimuli */
+    virtual void injectMultipleStimuli( const std::string& jsonParameters,
+                                        const brion::uint32_ts& cells ) = 0;
+
+    /** @copydoc Simulator::play */
+    virtual void play() = 0;
+
+    /** @copydoc Simulator::pause */
+    virtual void pause() = 0;
+
+    /** @copydoc Simulator::simulate*/
+    virtual void simulate( const double duration ) = 0;
+};
+
+}
+
+namespace boost
+{
+template<> inline
+std::string lexical_cast( const monsteer::SimulatorPluginInitData& data )
+{
+    return lexical_cast< std::string >( data.subscriber );
+}
+}
+
+#endif

--- a/nrp/steering/statusRequestMsg.fbs
+++ b/nrp/steering/statusRequestMsg.fbs
@@ -1,0 +1,14 @@
+// Copyright (c) 2015, EPFL/Blue Brain Project
+//                     Jafet Villafranca Diaz <jafet.villafrancadiaz@epfl.ch>
+//
+// Copyright (c) 2015, FZI/Human Brain Project
+//                     Martin Asghar Schulze <schulze@fzi.de>
+//
+namespace monsteer.steering;
+
+table StatusRequestMsg 
+{
+  messageID:string;
+}
+
+root_type StatusRequestMsg;

--- a/nrp/steering/vocabulary.cpp
+++ b/nrp/steering/vocabulary.cpp
@@ -21,7 +21,6 @@
 #include "../monsteer/steering/vocabulary.h"
 
 #include <monsteer/stimulus_generated.h>
-#include <monsteer/playbackState_generated.h>
 #include "runSimTrigger_generated.h"
 #include "statusRequestMsg_generated.h"
 #include "proxyStatusMsg_generated.h"
@@ -80,26 +79,6 @@ Stimulus deserializeStimulus( const zeq::Event& event )
     return stimulus;
 }
 
-zeq::Event serializePlaybackState( const std::string& messageID,
-                                   const SimulationPlaybackState::State state )
-{
-    zeq::Event event( EVENT_PLAYBACKSTATE );
-    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
-    auto fbMessageID = fbb.CreateString( messageID );
-    fbb.Finish( CreatePlaybackState( fbb, fbMessageID, state ));
-    return event;
-}
-
-SimulationPlaybackState deserializePlaybackState( const zeq::Event &event )
-{
-    auto data = GetPlaybackState( event.getData( ));
-
-    SimulationPlaybackState state;
-    state.messageID = data->messageID()->c_str();
-    state.state = (SimulationPlaybackState::State)data->state();
-
-    return state;
-}
 
 zeq::Event serializeSimulationRunTrigger( const std::string& messageID,
                                        const double duration )

--- a/nrp/steering/vocabulary.cpp
+++ b/nrp/steering/vocabulary.cpp
@@ -1,0 +1,175 @@
+
+/* Copyright (c) 2006-2015, Jafet Villafranca Diaz <jafet.villafrancadiaz@epfl.ch>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "vocabulary.h"
+#include "../monsteer/steering/vocabulary.h"
+
+#include <monsteer/stimulus_generated.h>
+#include <monsteer/playbackState_generated.h>
+#include "runSimTrigger_generated.h"
+#include "statusRequestMsg_generated.h"
+#include "proxyStatusMsg_generated.h"
+
+namespace monsteer
+{
+namespace steering
+{
+
+
+zeq::Event serializeStimulus( const std::string& messageID,
+                              const brion::uint32_ts& cells,
+                              const std::string& params,
+                              const bool multiple )
+{
+    zeq::Event event( EVENT_STIMULUSINJECTION );
+    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
+
+    // This is required to make FlatBuffers aware of the event fields that
+    // contain their default values. Otherwise some information might be lost
+    // e.g. 'multiple' parameter when it is set to false (0)
+    fbb.ForceDefaults(true);
+
+    auto fbMessageID = fbb.CreateString( messageID );
+    auto fbEventType = fbb.CreateString( "EVENT_STIMULUSINJECTION" );
+    auto fbCells = fbb.CreateVector( cells.data(), cells.size( ));
+    auto fbParams = fbb.CreateString( params );
+
+    fbb.Finish( CreateStimulusInjection( fbb, fbMessageID, fbEventType,
+                                         fbCells, fbParams, multiple ));
+    return event;
+}
+
+zeq::Event serializeStimulus( const Stimulus& stimulus )
+{
+    return serializeStimulus( stimulus.messageID,
+                              stimulus.cells,
+                              stimulus.params,
+                              stimulus.multiple );
+}
+
+Stimulus deserializeStimulus( const zeq::Event& event )
+{
+    auto data = GetStimulusInjection( event.getData( ));
+
+    Stimulus stimulus;
+    stimulus.messageID = data->messageID()->c_str();
+    stimulus.cells.reserve( data->cells()->Length( ));
+    for( flatbuffers::uoffset_t i = 0; i < data->cells()->Length(); ++i )
+    {
+        stimulus.cells.push_back( data->cells()->Get( i ));
+    }
+    stimulus.params = data->params()->c_str();
+    stimulus.multiple = data->multiple();
+
+    return stimulus;
+}
+
+zeq::Event serializePlaybackState( const std::string& messageID,
+                                   const SimulationPlaybackState::State state )
+{
+    zeq::Event event( EVENT_PLAYBACKSTATE );
+    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
+    auto fbMessageID = fbb.CreateString( messageID );
+    fbb.Finish( CreatePlaybackState( fbb, fbMessageID, state ));
+    return event;
+}
+
+SimulationPlaybackState deserializePlaybackState( const zeq::Event &event )
+{
+    auto data = GetPlaybackState( event.getData( ));
+
+    SimulationPlaybackState state;
+    state.messageID = data->messageID()->c_str();
+    state.state = (SimulationPlaybackState::State)data->state();
+
+    return state;
+}
+
+zeq::Event serializeSimulationRunTrigger( const std::string& messageID,
+                                       const double duration )
+{
+    zeq::Event event( EVENT_RUNSIMTRIGGER );
+    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
+    auto fbMessageID = fbb.CreateString( messageID );
+
+    fbb.Finish( CreateRunSimTrigger( fbb, fbMessageID, duration ));
+    return event;
+
+}
+
+SimulationRunTrigger deserializeSimulationRunTrigger( const zeq::Event &event )
+{
+    auto data = GetRunSimTrigger( event.getData(  ));
+
+    SimulationRunTrigger trigger;
+    trigger.messageID = data->messageID()->c_str();
+    trigger.duration = (double)data->duration();
+
+    return trigger;
+}
+
+ProxyStatus deserializeProxyStatus( const zeq::Event& event )
+{
+    auto data = GetProxyStatusMsg( event.getData( ));
+
+    ProxyStatus status;
+    status.messageID = data->messageID()->c_str();
+    status.state = (ProxyStatus::State)data->state();
+    
+    return status;
+}
+
+zeq::Event serializeProxyStatus( const std::string& messageID, const ProxyStatus::State state )
+{
+    zeq::Event event( EVENT_PROXYSTATUSMSG );
+    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
+    auto fbMessageID = fbb.CreateString( messageID );
+
+    fbb.Finish( CreateProxyStatusMsg( fbb, fbMessageID, state) );
+    return event;
+
+}
+
+StatusRequest deserializeStatusRequest( const zeq::Event& event )
+{
+    auto data = GetStatusRequestMsg( event.getData( ));
+
+    StatusRequest request;
+    request.messageID = data->messageID()->c_str();
+    
+    return request;
+}
+
+zeq::Event serializeStatusRequest( const std::string& messageID )
+{
+    zeq::Event event( EVENT_STATUSREQUESTMSG );
+    flatbuffers::FlatBufferBuilder& fbb = event.getFBB();
+    auto fbMessageID = fbb.CreateString( messageID );
+
+    fbb.Finish( CreateStatusRequestMsg( fbb, fbMessageID ) );
+    return event;
+
+}
+
+
+
+
+
+}
+}

--- a/nrp/steering/vocabulary.h
+++ b/nrp/steering/vocabulary.h
@@ -1,0 +1,90 @@
+
+/* Copyright (c) 2006-2015, Jafet Villafranca Diaz <jafet.villafrancadiaz@epfl.ch>
+ *
+ * This file is part of Monsteer <https://github.com/BlueBrain/Monsteer>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
+#ifndef NRP_STEERING_VOCABULARY_H
+#define NRP_STEERING_VOCABULARY_H
+
+#include <zeq/types.h>
+#include <zeq/event.h>
+
+#include <nrp/runSimTrigger_zeq_generated.h>
+#include <nrp/statusRequestMsg_zeq_generated.h>
+#include <nrp/proxyStatusMsg_zeq_generated.h>
+
+#include <monsteer/types.h>
+
+namespace monsteer
+{
+namespace steering
+{
+
+
+struct SimulationRunTrigger
+{
+    SimulationRunTrigger()
+        : duration(20.0)
+    {}
+
+    std::string messageID;
+    double duration;
+
+};
+
+struct ProxyStatus 
+{
+    enum State
+    {
+        READY = 0u,
+        BUSY = 1u
+    };
+
+    ProxyStatus()
+    {}
+
+    std::string messageID;
+    State state;
+};
+
+struct StatusRequest
+{
+    StatusRequest()
+    {}
+
+    std::string messageID;
+};
+
+zeq::Event serializeSimulationRunTrigger( const std::string& messageID,
+                                       const double duration );
+
+SimulationRunTrigger deserializeSimulationRunTrigger( const zeq::Event& event );
+
+zeq::Event serializeStatusRequest( const std::string& messageID );
+
+StatusRequest deserializeStatusRequest( const zeq::Event& event );
+
+zeq::Event serializeProxyStatus( const std::string& messageID,
+                                 const ProxyStatus::State state );
+
+ProxyStatus deserializeProxyStatus( const zeq::Event& event );
+
+
+}
+}
+#endif // NRP_STEERING_VOCABULARY_H


### PR DESCRIPTION
This pull request is meant to be to allow you to review my code and if I am using the sockets somehow wrong.

We could re-name the nrp_proxy to thalamus (as suggested by Juan) but then the previous simulator API (and abstract classes) and the one in development now collide; 

We could either leave the simulator API as it is for the original monsteer applications and make a new one (including new abstract classes) for thalamus  or we maybe could have a common abstract base class for both derived simulator-classes/abstract simulator classes. Or any better design.  In the current state I simply duplicated the code but I'll change that as soon as we have made decisions on the architecture.